### PR TITLE
Changes to compile with NVHPC >= 24.11

### DIFF
--- a/packages/yambo/package.py
+++ b/packages/yambo/package.py
@@ -476,3 +476,15 @@ class Yambo(AutotoolsPackage,CudaPackage,ROCmPackage):
     def install(self, spec, prefix):
         # 'install' target is not present
         install_tree('bin', prefix.bin)
+
+    def build(self, spec, prefix):
+        print(f"Using compiler: {spec.compiler.name} {spec.compiler.version}")
+        if spec.satisfies('%nvhpc') and spec.compiler.version >= Version('24.11') :
+            # Modify the config/setup file that was created by configure
+            config_file = join_path(self.stage.source_path, 'config', 'setup')
+            # Handle the -Mcuda=A,X pattern
+            filter_file( r'-Mcuda=([^,\s]+),([^,\s]+)', r'-cuda -gpu=\1,\2', config_file )
+            # Handle the -Mcudalib pattern
+            filter_file( r'-Mcudalib=([^,\s][^,\s]*(?:,[^,\s]+)*)', r'-cudalib=\1', config_file )
+        # Then proceed with the actual build
+        super(Yambo, self).build(spec, prefix)

--- a/packages/yambo/package.py
+++ b/packages/yambo/package.py
@@ -315,7 +315,7 @@ class Yambo(AutotoolsPackage,CudaPackage,ROCmPackage):
             env.set('MPIFC', 'mpifort')
         if '%nvhpc' in spec:
             env.set('FC', "nvfortran")
-            env.set('CPP', "cpp -E")
+            env.set('CPP', "cpp -E -P")
             env.set('FPP', "nvfortran -Mpreprocess -E")
             env.set('F90SUFFIX', ".f90")
             env.unset('CUDA_HOME')


### PR DESCRIPTION
I found several problems trying to use this recipe in Marenostrum V.

- The C preprocesor generates line markers during the compilation of YAMBO
- Some deprecated flags should not be used with nvhpc >= 24.11. I guess, this should be considered inside the yambo configure, but it solves the problem.
